### PR TITLE
HOTFIX: stack load/store always use register for offset & old stack dealloc in lit tests

### DIFF
--- a/llvm/lib/Target/CDM/CDMRegisterInfo.cpp
+++ b/llvm/lib/Target/CDM/CDMRegisterInfo.cpp
@@ -95,7 +95,7 @@ bool CDMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   MI.getOperand(I).ChangeToImmediate(FpOffset);
 
   // Opcode -> (Opcode, MemSize)
-  static const std::map<unsigned, std::pair<unsigned, unsigned>>
+  static const std::map<unsigned, std::pair<unsigned, int>>
       FPRelSubstitutionOpcsTable = {
           {CDM::ssw, {CDM::stwRR, 2}},   {CDM::lsw, {CDM::ldwRR, 2}},
           {CDM::ssb, {CDM::stbRR, 1}},   {CDM::lsb, {CDM::ldbRR, 1}},

--- a/llvm/test/CodeGen/CDM/calling_convention_ptr_to_arg_on_reg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_ptr_to_arg_on_reg.ll
@@ -29,7 +29,6 @@ entry:
 ; CHECK-NEXT: addsp 8
 ; CHECK-NEXT: lsw r0, -2
 ; CHECK-NEXT: add r0, 1
-; CHECK-NEXT: addsp 2
 ; CHECK-NEXT: stsp fp
 ; CHECK-NEXT: pop fp
 ; CHECK-NEXT: rts

--- a/llvm/test/CodeGen/CDM/calling_convention_vararg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_vararg.ll
@@ -17,7 +17,6 @@ entry:
 ; CHECK-NEXT: ssw r2, 8
 ; CHECK-NEXT: ssw r1, 6
 ; CHECK-NEXT: add r1, r0, r0
-; CHECK-NEXT: addsp 2
 ; CHECK-NEXT: stsp fp
 ; CHECK-NEXT: pop fp
 ; CHECK-NEXT: rts

--- a/llvm/test/CodeGen/CDM/char_arr.c
+++ b/llvm/test/CodeGen/CDM/char_arr.c
@@ -9,6 +9,5 @@ void foo(char a, char b, char c){
 // CHECK-NEXT: ssb r0, -1
 // CHECK-NEXT: ssb r1, -2
 // CHECK-NEXT: ssb r2, -3
-// CHECK-NEXT: addsp 4
 	volatile char arr[] = {a, b, c};
 }


### PR DESCRIPTION
days without bugs in main: 0