### PR TITLE
HOTFIX: Bad label names

### DIFF
--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
@@ -36,16 +36,16 @@ CDMAsmStreamer::CDMAsmStreamer(MCContext &Context,
 static void printSymbolName(StringRef Name, raw_ostream &OS) {
   // TODO This symbol name correction is temporary until we have
   // quoted symbol names in cocas.
-  //
-  // This can still produce invalid symbol names, because we don't
-  // ensure that symbol names don't start with a dot or a digit or
-  // end with a dot.
-  for (char C : Name) {
-    if (std::isalnum(C) || C == '_' || C == '.') {
+  for (size_t I = 0; I < Name.size(); ++I) {
+    char C = Name[I];
+    bool IsFirst = I == 0;
+    bool IsLast = I == Name.size() - 1;
+    if (std::isalpha(C) || C == '_' || (std::isdigit(C) && !IsFirst) ||
+        (C == '.' && !IsFirst && !IsLast)) {
       OS << C;
     } else {
       OS << "___";
-      OS << llvm::format("%02X", (unsigned)C);
+      OS << llvm::format("%02X", (unsigned char)C);
       OS << "___";
     }
   }
@@ -133,7 +133,8 @@ void CDMAsmStreamer::visitUsedSymbol(const MCSymbol &Sym) {
 
 static inline char toOctal(int X) { return (X & 7) + '0'; }
 
-static void printQuotedString(StringRef Data, raw_ostream &OS, bool AllowNonAscii = false) {
+static void printQuotedString(StringRef Data, raw_ostream &OS,
+                              bool AllowNonAscii = false) {
   OS << '"';
   for (unsigned char C : Data) {
     switch (C) {
@@ -402,6 +403,4 @@ void CDMAsmStreamer::emitExtList() {
   }
 }
 
-void CDMAsmStreamer::emitEnd() {
-  OS << "end.";
-}
+void CDMAsmStreamer::emitEnd() { OS << "end."; }

--- a/llvm/test/CodeGen/CDM/symbol_names.ll
+++ b/llvm/test/CodeGen/CDM/symbol_names.ll
@@ -1,0 +1,60 @@
+target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+
+; RUN: llc -mtriple=cdm < %s | FileCheck %s
+
+; Test label name correction
+
+; CHECK-LABEL: main>
+define void @main() #0 {
+    ret void
+}
+
+; CHECK-LABEL: a___24___main___24___b>
+define void @a$main$b() #0 {
+    ret void
+}
+
+; CHECK-LABEL: ___2E___foo>
+define void @".foo"() #0 {
+    ret void
+}
+
+; CHECK-LABEL: a.foo>
+define void @"a.foo"() #0 {
+    ret void
+}
+
+; CHECK-LABEL: bar___2E___>
+define void @"bar."() #0 {
+    ret void
+}
+
+; CHECK-LABEL: ___30______2E___>
+define void @"0."() #0 {
+    ret void
+}
+
+; CHECK-LABEL: ___30___foo___2E___>
+define void @"0foo."() #0 {
+    ret void
+}
+
+; CHECK-LABEL: ___30___0abc>
+define void @"00abc"() #0 {
+    ret void
+}
+
+; CHECK-LABEL: a0b1>
+define void @"a0b1"() #0 {
+    ret void
+}
+
+; CHECK-LABEL: ___25______3C____hehe____3E___>
+define void @"%<_hehe_>"() #0 {
+    ret void
+}
+
+; CHECK-LABEL: ___D0______BF______D1______80______D0______B8______D0______B2______D0______B5______D1______82___>
+define void @"привет"() #0 {
+    ret void
+}


### PR DESCRIPTION
Fixes a bug where non-alnum characters above 0x80 were converted into 32-bit integers before being printed (as 8 characters).
Also adds some missing logic so that our backend never produces invalid identifiers.

closes #36 