### PR TITLE
Remove cocas-related workarounds

### DIFF
--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
@@ -39,9 +39,8 @@ static void printSymbolName(StringRef Name, raw_ostream &OS) {
   for (size_t I = 0; I < Name.size(); ++I) {
     char C = Name[I];
     bool IsFirst = I == 0;
-    bool IsLast = I == Name.size() - 1;
-    if (std::isalpha(C) || C == '_' || (std::isdigit(C) && !IsFirst) ||
-        (C == '.' && !IsFirst && !IsLast)) {
+    if (std::isalpha(C) || (std::isdigit(C) && !IsFirst) || C == '_' ||
+        C == '.') {
       OS << C;
     } else {
       OS << "___";
@@ -179,24 +178,10 @@ static void printQuotedString(StringRef Data, raw_ostream &OS,
   OS << '"';
 }
 
-static bool canPrintAsQuotedString(StringRef Data) {
-  for (char C : Data) {
-    // Cocas has UTF-8 strings so they cannot have arbitrary bytes
-    if ((unsigned)C > 127) {
-      return false;
-    }
-  }
-  return true;
-}
-
 void CDMAsmStreamer::emitBytes(StringRef Data) {
-  if (canPrintAsQuotedString(Data)) {
-    OS << "\tdb\t";
-    printQuotedString(Data, OS);
-    emitEOL();
-  } else {
-    emitBinaryData(Data);
-  }
+  OS << "\tdb\t";
+  printQuotedString(Data, OS);
+  emitEOL();
 }
 
 void CDMAsmStreamer::emitBinaryData(StringRef Data) {

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMMCAsmInfo.cpp
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMMCAsmInfo.cpp
@@ -9,7 +9,7 @@ CDMMCAsmInfo::CDMMCAsmInfo(const Triple &TheTriple) {
   CodePointerSize = 2;
   MaxInstLength = 4;
   MinInstAlignment = 2;
-  PrivateGlobalPrefix = "__L";
-  PrivateLabelPrefix = "__L";
+  PrivateGlobalPrefix = ".L";
+  PrivateLabelPrefix = ".L";
 }
 } // namespace llvm

--- a/llvm/test/CodeGen/CDM/emit_string_non_unicode.c
+++ b/llvm/test/CodeGen/CDM/emit_string_non_unicode.c
@@ -1,8 +1,6 @@
 // RUN: clang -target cdm-cocas -O0 -S -o - %s | FileCheck %s
 
-// cocas strings are unicode-only so we emit
-// strings with non-ascii characters as byte arrays
-// because we can't directly insert bytes above 0x7f
+// non-ASCII characters should be encoded as octal
 
 const char string1[] = "\x7f\x70\005a";
 // CHECK-LABEL: string1>
@@ -10,8 +8,8 @@ const char string1[] = "\x7f\x70\005a";
 
 const char string2[] = "\x7f\x80\005a";
 // CHECK-LABEL: string2>
-// CHECK: db 0x7f, 0x80, 0x05, 0x61, 0x00
+// CHECK: db "\177\200\005a\000"
 
 const char string3[] = "ого!";
 // CHECK-LABEL: string3>
-// CHECK: db 0xd0, 0xbe, 0xd0, 0xb3, 0xd0, 0xbe, 0x21, 0x00
+// CHECK: db "\320\276\320\263\320\276!\000"

--- a/llvm/test/CodeGen/CDM/symbol_names.ll
+++ b/llvm/test/CodeGen/CDM/symbol_names.ll
@@ -14,7 +14,7 @@ define void @a$main$b() #0 {
     ret void
 }
 
-; CHECK-LABEL: ___2E___foo>
+; CHECK-LABEL: .foo>
 define void @".foo"() #0 {
     ret void
 }
@@ -24,17 +24,17 @@ define void @"a.foo"() #0 {
     ret void
 }
 
-; CHECK-LABEL: bar___2E___>
+; CHECK-LABEL: bar.>
 define void @"bar."() #0 {
     ret void
 }
 
-; CHECK-LABEL: ___30______2E___>
+; CHECK-LABEL: ___30___.>
 define void @"0."() #0 {
     ret void
 }
 
-; CHECK-LABEL: ___30___foo___2E___>
+; CHECK-LABEL: ___30___foo.>
 define void @"0foo."() #0 {
     ret void
 }


### PR DESCRIPTION
Removes some cocas-related workarounds:
- mangling of dots at the start of names
- not using the default `.L` as the prefix for local labels
- replacing strings with `db 0xXX 0xXX...` when there is a non-ascii character