### PR TITLE
Use ELF mangling for CDM

### DIFF
--- a/clang/lib/Basic/Targets/CDM.h
+++ b/clang/lib/Basic/Targets/CDM.h
@@ -44,8 +44,8 @@ public:
     Char16Type = UnsignedInt;
     Char32Type = UnsignedLong;
     SigAtomicType = SignedChar;
-    resetDataLayout("e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-"
-                    "f64:16-f128:16-m:C-n16");
+    resetDataLayout("e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-"
+                    "f64:16-f128:16-n16-S16");
   }
 
   bool allowsLargerPreferedTypeAlignment() const override { return false; }

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -113,8 +113,7 @@ private:
     MM_WinCOFFX86,
     MM_GOFF,
     MM_Mips,
-    MM_XCOFF,
-    MM_CDM
+    MM_XCOFF
   };
   ManglingModeT ManglingMode = MM_None;
 
@@ -276,7 +275,6 @@ public:
     case MM_Mips:
     case MM_WinCOFF:
     case MM_XCOFF:
-    case MM_CDM:
       return '\0';
     case MM_MachO:
     case MM_WinCOFFX86:
@@ -287,8 +285,6 @@ public:
 
   StringRef getPrivateGlobalPrefix() const {
     switch (ManglingMode) {
-    case MM_CDM:
-      return "__L";
     case MM_None:
       return "";
     case MM_ELF:

--- a/llvm/lib/IR/DataLayout.cpp
+++ b/llvm/lib/IR/DataLayout.cpp
@@ -598,10 +598,6 @@ Error DataLayout::parseSpecification(
     case 'a':
       ManglingMode = MM_XCOFF;
       break;
-
-    case 'C':
-      ManglingMode = MM_CDM;
-      break;
     }
     break;
   default:

--- a/llvm/lib/Target/CDM/CDMTargetMachine.cpp
+++ b/llvm/lib/Target/CDM/CDMTargetMachine.cpp
@@ -19,8 +19,8 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeCDMTarget() {
 static std::string computeDataLayout() {
   // XXX Build the triple from the arguments.
   // This is hard-coded for now for this example target.
-  return "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-"
-         "m:C-n16";
+  return "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-"
+         "n16-S16";
 }
 
 CDMTargetMachine::CDMTargetMachine(const Target &T, const Triple &TT,

--- a/llvm/test/CodeGen/CDM/add.ll
+++ b/llvm/test/CodeGen/CDM/add.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/addr_exprs.ll
+++ b/llvm/test/CodeGen/CDM/addr_exprs.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/alloca.ll
+++ b/llvm/test/CodeGen/CDM/alloca.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/and.ll
+++ b/llvm/test/CodeGen/CDM/and.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/big_stack_frame.ll
+++ b/llvm/test/CodeGen/CDM/big_stack_frame.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/builtins.ll
+++ b/llvm/test/CodeGen/CDM/builtins.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -O0 -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/calling_convention_basic.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_basic.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/calling_convention_extra_arg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_extra_arg.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/calling_convention_long_arg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_long_arg.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/calling_convention_long_long_arg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_long_long_arg.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/calling_convention_ptr_to_arg_on_reg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_ptr_to_arg_on_reg.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/calling_convention_vararg.ll
+++ b/llvm/test/CodeGen/CDM/calling_convention_vararg.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/conditional_branch_with_move.ll
+++ b/llvm/test/CodeGen/CDM/conditional_branch_with_move.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/constant_shift.ll
+++ b/llvm/test/CodeGen/CDM/constant_shift.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/ext.ll
+++ b/llvm/test/CodeGen/CDM/ext.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/func_ptr.ll
+++ b/llvm/test/CodeGen/CDM/func_ptr.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/global.ll
+++ b/llvm/test/CodeGen/CDM/global.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/inst_aliases.ll
+++ b/llvm/test/CodeGen/CDM/inst_aliases.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/intrinsics.ll
+++ b/llvm/test/CodeGen/CDM/intrinsics.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/isr.ll
+++ b/llvm/test/CodeGen/CDM/isr.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/load_i1.ll
+++ b/llvm/test/CodeGen/CDM/load_i1.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/multiple_ext.ll
+++ b/llvm/test/CodeGen/CDM/multiple_ext.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/no_locals.ll
+++ b/llvm/test/CodeGen/CDM/no_locals.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/private_label.ll
+++ b/llvm/test/CodeGen/CDM/private_label.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/public_label.ll
+++ b/llvm/test/CodeGen/CDM/public_label.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/returning_struct.ll
+++ b/llvm/test/CodeGen/CDM/returning_struct.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/shifts.ll
+++ b/llvm/test/CodeGen/CDM/shifts.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/sub.ll
+++ b/llvm/test/CodeGen/CDM/sub.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/symbol_names.ll
+++ b/llvm/test/CodeGen/CDM/symbol_names.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 

--- a/llvm/test/CodeGen/CDM/trap.ll
+++ b/llvm/test/CodeGen/CDM/trap.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-S16-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-m:C-n16"
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
 
 ; RUN: llc -mtriple=cdm-cocas < %s | FileCheck %s
 


### PR DESCRIPTION
This PR removes the custom "CDM" mangling scheme that uses "__L" as the local label prefix and uses ELF mangling with ".L" prefix instead.

We don't need custom mangling anymore becuase Cocas now supports '.' at the start of label names. And in AsmInfo we also have '.L'