### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/cdm-build.yaml
+++ b/.github/workflows/cdm-build.yaml
@@ -31,6 +31,7 @@ env:
     bin/llvm-size
     bin/llvm-strings
   RESOURCES: |
+    lib/clang
     lib/cdm
     lib/cdm-unknown-unknown-cocas
     include/cdm

--- a/.github/workflows/cdm-nightly.yaml
+++ b/.github/workflows/cdm-nightly.yaml
@@ -15,6 +15,8 @@ jobs:
   release:
     needs: build-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Create subfolder
         run: mkdir artifacts_download

--- a/.github/workflows/cdm-release.yaml
+++ b/.github/workflows/cdm-release.yaml
@@ -17,7 +17,6 @@ jobs:
   release:
     needs: build-test
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
This PR fixes incorrect permissions for the nightly build workflow and missing standard headers in distribution.