### PR TITLE
Add no-op atomic fences

### DIFF
--- a/llvm/lib/Target/CDM/CDMISelLowering.cpp
+++ b/llvm/lib/Target/CDM/CDMISelLowering.cpp
@@ -700,6 +700,10 @@ CDMISelLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   case CDM::SHR_EXT64_LOOP:
   case CDM::SHRA_EXT64_LOOP:
     return emitShiftLoop(MI, MBB);
+  case CDM::PseudoAtomicFence:
+    // Fences are no-op, since CDM-16 is single-core.
+    MI.eraseFromParent();
+    return MBB;
   }
 }
 

--- a/llvm/lib/Target/CDM/CDMInstrInfo.td
+++ b/llvm/lib/Target/CDM/CDMInstrInfo.td
@@ -961,6 +961,12 @@ let Defs = [SP], Uses = [SP] in {
                   [(callseq_end timm:$amt1, timm:$amt2)]>;
 }
 
+// Atomics
+let usesCustomInserter = true in {
+  def PseudoAtomicFence
+      : CDMPseudo<(outs), (ins), "", [(atomic_fence timm, timm)]>;
+}
+
 //===----------------------------------------------------------------------===//
 // Non-Instruction Patterns
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR implements atomic fences in the CDM backend. These are emitted when using `core::sync::atomic::compiler_fence` in Rust. Just like in AVR, they do nothing, because CDM-16 is a single core processor.