### PR TITLE
Fix `dbg_loc` emission 

### DIFF
--- a/llvm/lib/Target/CDM/CDMAsmPrinter.cpp
+++ b/llvm/lib/Target/CDM/CDMAsmPrinter.cpp
@@ -157,12 +157,6 @@ void CDMAsmPrinter::emitStartOfAsmFile(Module &Module) {
   getTargetStreamer()->emitRsect(llvm::formatv("_{0}_{1}", FN, rand()));
 }
 
-void CDMAsmPrinter::emitEndOfAsmFile(Module &Module) {
-  auto *TS = getTargetStreamer();
-  TS->emitExtList();
-  TS->emitEnd();
-}
-
 bool CDMAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
                                     const char *ExtraCode, raw_ostream &OS) {
   if (ExtraCode && ExtraCode[0]) {

--- a/llvm/lib/Target/CDM/CDMAsmPrinter.cpp
+++ b/llvm/lib/Target/CDM/CDMAsmPrinter.cpp
@@ -88,42 +88,40 @@ void CDMAsmPrinter::collectAndEmitSourceFiles(Module &Module) {
   }
 }
 
-void CDMAsmPrinter::emitInstruction(const MachineInstr *Instr) {
-  static unsigned PrevLineNumber = 0;
-  static int PrevFileIndex = -1;
+void CDMAsmPrinter::emitDebugLoc(DILocation &DebugLoc) {
+  StringRef Checksum = DebugLoc.getFile()->getChecksum().value().Value;
 
+  std::optional<int> NewFileIndex = getSourceFileIndex(Checksum);
+  if (!NewFileIndex) {
+    return;
+  }
+
+  unsigned NewLineNumber = DebugLoc.getLine();
+  unsigned NewColumnNumber = DebugLoc.getColumn();
+
+  if (SourceFileIndex != NewFileIndex || LineNumber != NewLineNumber ||
+      ColumnNumber != NewColumnNumber) {
+    SourceFileIndex = NewFileIndex;
+    LineNumber = NewLineNumber;
+    ColumnNumber = NewColumnNumber;
+
+    getTargetStreamer()->emitDbgLoc(*SourceFileIndex, *LineNumber,
+                                    *ColumnNumber, DebugLoc.getFilename());
+  }
+}
+
+void CDMAsmPrinter::emitInstruction(const MachineInstr *Instr) {
   if (Instr->isDebugValue()) {
     // TODO: implement
     return;
   }
-  if (Instr->isDebugLabel())
+  if (Instr->isDebugLabel()) {
     return;
+  }
 
   DILocation *DebugLoc = Instr->getDebugLoc().get();
-
   if (DebugLoc) {
-    StringRef Checksum = DebugLoc->getFile()->getChecksum().value().Value;
-
-    std::optional<int> SourceFileIndex = getSourceFileIndex(Checksum);
-
-    if (SourceFileIndex) {
-      unsigned CurrLineNumber = DebugLoc->getLine(),
-               CurrColumnNumber = DebugLoc->getColumn();
-
-      if (PrevLineNumber != CurrLineNumber ||
-          PrevFileIndex != SourceFileIndex) {
-
-        OutStreamer->getCommentOS()
-            << formatv("{0}:{1}:{2}", DebugLoc->getFilename(), CurrLineNumber,
-                       CurrColumnNumber)
-            << "\n";
-
-        getTargetStreamer()->emitDbgLoc(*SourceFileIndex, CurrLineNumber,
-                                        CurrColumnNumber);
-        PrevLineNumber = CurrLineNumber;
-        PrevFileIndex = *SourceFileIndex;
-      }
-    }
+    emitDebugLoc(*DebugLoc);
   }
 
   CDMMCInstLower MCInstLower(OutContext, *this);

--- a/llvm/lib/Target/CDM/CDMAsmPrinter.h
+++ b/llvm/lib/Target/CDM/CDMAsmPrinter.h
@@ -19,9 +19,13 @@ namespace llvm {
 
 class CDMAsmPrinter : public AsmPrinter {
   llvm::StringMap<int> SourceFiles;
+  std::optional<unsigned> SourceFileIndex;
+  std::optional<unsigned> LineNumber;
+  std::optional<unsigned> ColumnNumber;
 
   std::optional<int> getSourceFileIndex(StringRef Checksum);
   void collectAndEmitSourceFiles(Module &Module);
+  void emitDebugLoc(DILocation &DebugLoc);
 
 public:
   explicit CDMAsmPrinter(TargetMachine &TM,

--- a/llvm/lib/Target/CDM/CDMAsmPrinter.h
+++ b/llvm/lib/Target/CDM/CDMAsmPrinter.h
@@ -36,7 +36,6 @@ public:
 
   void emitInstruction(const MachineInstr *Instr) override;
   void emitStartOfAsmFile(Module &Module) override;
-  void emitEndOfAsmFile(Module &Module) override;
 
   bool PrintAsmOperand(const MachineInstr *MI, unsigned OpNum,
                        const char *ExtraCode, raw_ostream &O) override;

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
@@ -11,6 +11,7 @@
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -373,9 +374,10 @@ void CDMAsmStreamer::emitDbgSource(unsigned FileIndex, const Twine &FileName) {
   emitEOL();
 }
 
-void CDMAsmStreamer::emitDbgLoc(unsigned Index, unsigned Line,
-                                unsigned Column) {
+void CDMAsmStreamer::emitDbgLoc(unsigned Index, unsigned Line, unsigned Column,
+                                const Twine &FileName) {
   OS << "\tdbg_loc " << Index << ", " << Line << ", " << Column;
+  AddComment(formatv("{0}:{1}:{2}", FileName, Line, Column));
   emitEOL();
 }
 

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.cpp
@@ -390,4 +390,9 @@ void CDMAsmStreamer::emitExtList() {
   }
 }
 
-void CDMAsmStreamer::emitEnd() { OS << "end."; }
+void CDMAsmStreamer::finishImpl() {
+  emitExtList();
+
+  OS << "end.";
+  emitEOL();
+}

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.h
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.h
@@ -44,7 +44,8 @@ public:
   // CDM-specific functions
   void emitRsect(const Twine &Name);
   void emitDbgSource(unsigned FileIndex, const Twine &FileName);
-  void emitDbgLoc(unsigned Index, unsigned Line, unsigned Column);
+  void emitDbgLoc(unsigned Index, unsigned Line, unsigned Column,
+                  const Twine &FileName);
   void emitExtList();
   void emitEnd();
 

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.h
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMAsmStreamer.h
@@ -28,6 +28,8 @@ class CDMAsmStreamer : public MCStreamer {
 
   bool EmittedSectionDirective = false;
 
+  void emitExtList();
+
 protected:
   void emitRawTextImpl(StringRef String) override;
 
@@ -46,8 +48,6 @@ public:
   void emitDbgSource(unsigned FileIndex, const Twine &FileName);
   void emitDbgLoc(unsigned Index, unsigned Line, unsigned Column,
                   const Twine &FileName);
-  void emitExtList();
-  void emitEnd();
 
   MCInstPrinter *getInstPrinter() { return InstPrinter.get(); }
   MCAssembler *getAssemblerPtr() override { return nullptr; }
@@ -108,6 +108,8 @@ public:
                 SMLoc Loc = SMLoc()) override;
 
   void reset() override;
+
+  void finishImpl() override;
 
   static bool classof(const MCStreamer *S) { return S->hasRawTextSupport(); }
 };

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMTargetStreamer.h
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMTargetStreamer.h
@@ -17,8 +17,6 @@ public:
   virtual void emitDbgSource(unsigned FileIndex, const Twine &FileName) {}
   virtual void emitDbgLoc(unsigned FileIndex, unsigned Line, unsigned Column,
                           const Twine &FileName) {}
-  virtual void emitExtList() {}
-  virtual void emitEnd() {}
 };
 
 class CDMTargetAsmStreamer : public CDMTargetStreamer {
@@ -41,10 +39,6 @@ public:
                   const Twine &FileName) override {
     getAsmStreamer()->emitDbgLoc(FileIndex, Line, Column, FileName);
   }
-
-  void emitExtList() override { getAsmStreamer()->emitExtList(); }
-
-  void emitEnd() override { getAsmStreamer()->emitEnd(); }
 
   CDMAsmStreamer *getAsmStreamer() const {
     return static_cast<CDMAsmStreamer *>(&Streamer);

--- a/llvm/lib/Target/CDM/MCTargetDesc/CDMTargetStreamer.h
+++ b/llvm/lib/Target/CDM/MCTargetDesc/CDMTargetStreamer.h
@@ -15,7 +15,8 @@ public:
 
   virtual void emitRsect(const Twine &Name) {}
   virtual void emitDbgSource(unsigned FileIndex, const Twine &FileName) {}
-  virtual void emitDbgLoc(unsigned Index, unsigned Line, unsigned Column) {}
+  virtual void emitDbgLoc(unsigned FileIndex, unsigned Line, unsigned Column,
+                          const Twine &FileName) {}
   virtual void emitExtList() {}
   virtual void emitEnd() {}
 };
@@ -36,8 +37,9 @@ public:
     getAsmStreamer()->emitDbgSource(FileIndex, FileName);
   }
 
-  void emitDbgLoc(unsigned Index, unsigned Line, unsigned Column) override {
-    getAsmStreamer()->emitDbgLoc(Index, Line, Column);
+  void emitDbgLoc(unsigned FileIndex, unsigned Line, unsigned Column,
+                  const Twine &FileName) override {
+    getAsmStreamer()->emitDbgLoc(FileIndex, Line, Column, FileName);
   }
 
   void emitExtList() override { getAsmStreamer()->emitExtList(); }


### PR DESCRIPTION
Previous implementation used to cause assertion errors and segfaults in rustc when compiling with debug (it doesn't even use cocas).