### PR TITLE
Fix compare libcall return type

### DIFF
--- a/llvm/lib/Target/CDM/CDMISelLowering.h
+++ b/llvm/lib/Target/CDM/CDMISelLowering.h
@@ -72,6 +72,10 @@ public:
   Register getRegisterByName(const char *RegName, LLT VT,
                              const MachineFunction &MF) const override;
 
+  MVT::SimpleValueType getCmpLibcallReturnType() const override {
+      return MVT::i16;
+  }
+
 private:
   SDValue lowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerExternalSymbol(SDValue Op, SelectionDAG &DAG) const;


### PR DESCRIPTION
Default was `i32`, changed to `i16`, as 32 bits were unnecessary. `i32` also broke Rust, which expected the return type to be `isize`.