### PR TITLE
Add support for ISA extensions

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -31,6 +31,7 @@ add_clang_library(clangDriver
   ToolChain.cpp
   ToolChains/Arch/AArch64.cpp
   ToolChains/Arch/ARM.cpp
+  ToolChains/Arch/CDM.cpp
   ToolChains/Arch/CSKY.cpp
   ToolChains/Arch/LoongArch.cpp
   ToolChains/Arch/M68k.cpp

--- a/clang/lib/Driver/ToolChains/Arch/CDM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/CDM.cpp
@@ -1,0 +1,24 @@
+#include "CDM.h"
+#include "llvm/TargetParser/CDMTargetParser.h"
+
+#include "clang/Driver/Driver.h"
+#include "llvm/Option/ArgList.h"
+
+using namespace clang::driver;
+using namespace clang::driver::tools;
+using namespace clang;
+using namespace llvm::opt;
+
+void cdm::getCDMTargetFeatures(const Driver &D, const llvm::Triple &Triple,
+                               const ArgList &Args,
+                               std::vector<StringRef> &Features) {
+
+  const Arg *MArch = Args.getLastArg(options::OPT_march_EQ);
+  if (!MArch) {
+    return;
+  }
+  StringRef ArchName = MArch->getValue();
+  if (!llvm::CDM::getArchFeatures(ArchName, Features)) {
+    D.Diag(diag::err_drv_invalid_arch_name) << ArchName;
+  }
+}

--- a/clang/lib/Driver/ToolChains/Arch/CDM.h
+++ b/clang/lib/Driver/ToolChains/Arch/CDM.h
@@ -1,0 +1,21 @@
+#ifndef LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_CDM_H
+#define LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_CDM_H
+
+#include "clang/Driver/Driver.h"
+#include "llvm/ADT/StringRef.h"
+#include <vector>
+
+namespace clang {
+namespace driver {
+namespace tools {
+namespace cdm {
+
+void getCDMTargetFeatures(const Driver &D, const llvm::Triple &Triple,
+                          const llvm::opt::ArgList &Args,
+                          std::vector<llvm::StringRef> &Features);
+} // end namespace cdm
+} // end namespace tools
+} // end namespace driver
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_CDM_H

--- a/clang/lib/Driver/ToolChains/Cocas.cpp
+++ b/clang/lib/Driver/ToolChains/Cocas.cpp
@@ -6,11 +6,11 @@
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
 #include "clang/Driver/Types.h"
-#include "llvm/TargetParser/Triple.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
+#include "llvm/TargetParser/Triple.h"
 #include <cstdlib>
 #include <cstring>
 #include <optional>
@@ -38,7 +38,8 @@ void CDM::Cocas::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-c");
   }
   // If job kind is link and incremental linking requested, "Merge" objects
-  else if (JA.getKind() == Action::LinkJobClass && Args.hasArg(options::OPT_r)) {
+  else if (JA.getKind() == Action::LinkJobClass &&
+           Args.hasArg(options::OPT_r)) {
     CmdArgs.push_back("-m");
   }
 
@@ -59,9 +60,10 @@ void CDM::Cocas::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  // Target cdm16
+  // Target settings
   CmdArgs.push_back("-t");
-  CmdArgs.push_back("cdm16");
+  CmdArgs.push_back(
+      Args.MakeArgString(Args.getLastArgValue(options::OPT_march_EQ, "cdm16")));
 
   // Add output file
   CmdArgs.push_back("-o");
@@ -75,23 +77,26 @@ void CDM::Cocas::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (JA.getKind() == Action::LinkJobClass) {
-    if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib, options::OPT_r)) {
+    if (!Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib,
+                     options::OPT_r)) {
       CmdArgs.push_back(
           Args.MakeArgString(getCocasToolChain().GetFilePath("crt0.o")));
     }
-    if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs, options::OPT_r)){
-        // Add object files from standard lib
-        for (const char *obj : getCocasToolChain().getStdLibObjs()) {
-          CmdArgs.push_back(
-              Args.MakeArgString(getCocasToolChain().GetFilePath(obj)));
-        }
+    if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+                     options::OPT_r)) {
+      // Add object files from standard lib
+      for (const char *obj : getCocasToolChain().getStdLibObjs()) {
+        CmdArgs.push_back(
+            Args.MakeArgString(getCocasToolChain().GetFilePath(obj)));
+      }
     }
-    if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs, options::OPT_r)){
-        // Add builtins
-        for (const char *obj : getCocasToolChain().getBuiltinNames()) {
-          CmdArgs.push_back(getCocasToolChain().getCompilerRTArgString(
-              Args, obj, ToolChain::FT_Object));
-        }
+    if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+                     options::OPT_r)) {
+      // Add builtins
+      for (const char *obj : getCocasToolChain().getBuiltinNames()) {
+        CmdArgs.push_back(getCocasToolChain().getCompilerRTArgString(
+            Args, obj, ToolChain::FT_Object));
+      }
     }
 
     std::vector<std::string> libSearchDirs =
@@ -193,10 +198,10 @@ void CocasToolChain::AddClangSystemIncludeArgs(
     llvm::opt::ArgStringList &CC1Args) const {
 
   if (DriverArgs.hasArg(options::OPT_nostdinc) ||
-      DriverArgs.hasArg(options::OPT_nostdlibinc)){
+      DriverArgs.hasArg(options::OPT_nostdlibinc)) {
     return;
   }
-  if (getIncludePath()){
+  if (getIncludePath()) {
     addSystemInclude(DriverArgs, CC1Args, *getIncludePath());
   }
 }

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -9,6 +9,7 @@
 #include "clang/Driver/CommonArgs.h"
 #include "Arch/AArch64.h"
 #include "Arch/ARM.h"
+#include "Arch/CDM.h"
 #include "Arch/CSKY.h"
 #include "Arch/LoongArch.h"
 #include "Arch/M68k.h"
@@ -888,6 +889,9 @@ void tools::getTargetFeatures(const Driver &D, const llvm::Triple &Triple,
   case llvm::Triple::loongarch32:
   case llvm::Triple::loongarch64:
     loongarch::getLoongArchTargetFeatures(D, Triple, Args, Features);
+    break;
+  case llvm::Triple::cdm:
+    cdm::getCDMTargetFeatures(D, Triple, Args, Features);
     break;
   }
 

--- a/llvm/include/llvm/TargetParser/CDMTargetParser.def
+++ b/llvm/include/llvm/TargetParser/CDMTargetParser.def
@@ -1,5 +1,5 @@
 #ifndef CDM_EXTENSION
 #define CDM_EXTENSION(ARCH_NAME, FLAG_NAME)
 #endif
-CDM_EXTENSION('m', "+M")
-CDM_EXTENSION('e', "+E")
+CDM_EXTENSION('m', "+m")
+CDM_EXTENSION('e', "+e")

--- a/llvm/include/llvm/TargetParser/CDMTargetParser.def
+++ b/llvm/include/llvm/TargetParser/CDMTargetParser.def
@@ -2,3 +2,4 @@
 #define CDM_EXTENSION(ARCH_NAME, FLAG_NAME)
 #endif
 CDM_EXTENSION('m', "+M")
+CDM_EXTENSION('e', "+E")

--- a/llvm/include/llvm/TargetParser/CDMTargetParser.def
+++ b/llvm/include/llvm/TargetParser/CDMTargetParser.def
@@ -1,0 +1,4 @@
+#ifndef CDM_EXTENSION
+#define CDM_EXTENSION(ARCH_NAME, FLAG_NAME)
+#endif
+CDM_EXTENSION('m', "+M")

--- a/llvm/include/llvm/TargetParser/CDMTargetParser.h
+++ b/llvm/include/llvm/TargetParser/CDMTargetParser.h
@@ -1,0 +1,24 @@
+#ifndef LLVM_TARGETPARSER_CDMTARGETPARSER_H
+#define LLVM_TARGETPARSER_CDMTARGETPARSER_H
+
+#include "llvm/Support/Compiler.h"
+#include "llvm/ADT/StringRef.h"
+#include <vector>
+
+namespace llvm {
+class StringRef;
+
+namespace CDM {
+
+struct ExtensionInfo {
+  char ArchName;
+  StringRef FlagName;
+};
+
+LLVM_ABI bool getArchFeatures(StringRef Arch, std::vector<StringRef> &Features);
+
+} // namespace CDM
+
+} // namespace llvm
+
+#endif // LLVM_TARGETPARSER_CDMTARGETPARSER_H

--- a/llvm/lib/Target/CDM/CDM.td
+++ b/llvm/lib/Target/CDM/CDM.td
@@ -1,4 +1,5 @@
 include "llvm/Target/Target.td"
+include "CDMExtensions.td"
 include "CDMRegisterInfo.td"
 include "CDMInstrInfo.td"
 include "CDMCallingConv.td"

--- a/llvm/lib/Target/CDM/CDMExtensions.td
+++ b/llvm/lib/Target/CDM/CDMExtensions.td
@@ -2,3 +2,4 @@ class CDMExtension<string name, string desc, list<SubtargetFeature> implies = []
     : SubtargetFeature<name, !subst("Extension", "HasExt", NAME), "true", desc, implies>;
 
 def ExtensionM : CDMExtension<"M", "Integer multiplication and division">;
+def ExtensionE : CDMExtension<"E", "Operating system support">;

--- a/llvm/lib/Target/CDM/CDMExtensions.td
+++ b/llvm/lib/Target/CDM/CDMExtensions.td
@@ -1,5 +1,5 @@
 class CDMExtension<string name, string desc, list<SubtargetFeature> implies = []>
     : SubtargetFeature<name, !subst("Extension", "HasExt", NAME), "true", desc, implies>;
 
-def ExtensionM : CDMExtension<"M", "Integer multiplication and division">;
-def ExtensionE : CDMExtension<"E", "Operating system support">;
+def ExtensionM : CDMExtension<"m", "Integer multiplication and division">;
+def ExtensionE : CDMExtension<"e", "Operating system support">;

--- a/llvm/lib/Target/CDM/CDMExtensions.td
+++ b/llvm/lib/Target/CDM/CDMExtensions.td
@@ -1,0 +1,4 @@
+class CDMExtension<string name, string desc, list<SubtargetFeature> implies = []>
+    : SubtargetFeature<name, !subst("Extension", "HasExt", NAME), "true", desc, implies>;
+
+def ExtensionM : CDMExtension<"M", "Integer multiplication and division">;

--- a/llvm/lib/Target/CDM/CDMISelLowering.cpp
+++ b/llvm/lib/Target/CDM/CDMISelLowering.cpp
@@ -72,7 +72,7 @@ CDMISelLowering::CDMISelLowering(const CDMTargetMachine &TM,
   setOperationAction(ISD::SETCC, MVT::i16, Expand);
 
   // 32-bit and 64-bit shifts are expanded into shift-rotate chains
-  // or loops if the shift amount is variable.
+  // or loops if the shift amount is variable
   setOperationAction(ISD::SHL, MVT::i32, Custom);
   setOperationAction(ISD::SRL, MVT::i32, Custom);
   setOperationAction(ISD::SRA, MVT::i32, Custom);
@@ -83,31 +83,37 @@ CDMISelLowering::CDMISelLowering(const CDMTargetMachine &TM,
   setOperationAction(ISD::SRL_PARTS, MVT::i16, Expand);
   setOperationAction(ISD::SRA_PARTS, MVT::i16, Expand);
 
-  // We don't support multiplication/division natively,
-  // so they are lowered to libcalls.
-  setOperationAction(ISD::MUL, MVT::i16, LibCall);
-  setOperationAction(ISD::SMUL_LOHI, MVT::i16, Expand);
-  setOperationAction(ISD::UMUL_LOHI, MVT::i16, Expand);
+  // We have an optional mul/div extension
+  if (!Subtarget.hasExtM()) {
+    setOperationAction(ISD::SDIVREM, MVT::i16, Expand);
+    setOperationAction(ISD::UDIVREM, MVT::i16, Expand);
+    setOperationAction(ISD::SMUL_LOHI, MVT::i16, Expand);
+    setOperationAction(ISD::UMUL_LOHI, MVT::i16, Expand);
+  }
+
+  // Other kinds of mul/div operations are expanded
+  setOperationAction(ISD::MUL, MVT::i16, Expand);
   setOperationAction(ISD::MULHS, MVT::i16, Expand);
   setOperationAction(ISD::MULHU, MVT::i16, Expand);
-  setOperationAction(ISD::SDIV, MVT::i16, LibCall);
-  setOperationAction(ISD::UDIV, MVT::i16, LibCall);
-  setOperationAction(ISD::SDIVREM, MVT::i16, Expand);
-  setOperationAction(ISD::UDIVREM, MVT::i16, Expand);
-  setOperationAction(ISD::SREM, MVT::i16, LibCall);
-  setOperationAction(ISD::UREM, MVT::i16, LibCall);
+  setOperationAction(ISD::SDIV, MVT::i16, Expand);
+  setOperationAction(ISD::UDIV, MVT::i16, Expand);
+  setOperationAction(ISD::SREM, MVT::i16, Expand);
+  setOperationAction(ISD::UREM, MVT::i16, Expand);
 
+  // Custom lowering for 32/64 bit addition and subtraction
+  // that generates better code
   setOperationAction(ISD::ADD, MVT::i32, Custom);
   setOperationAction(ISD::SUB, MVT::i32, Custom);
   setOperationAction(ISD::ADD, MVT::i64, Custom);
   setOperationAction(ISD::SUB, MVT::i64, Custom);
 
-  // Expand other ops
+  // Bit ops are expanded
   setOperationAction(ISD::BSWAP, MVT::i16, Expand);
   setOperationAction(ISD::CTLZ, MVT::i16, Expand);
   setOperationAction(ISD::CTTZ, MVT::i16, Expand);
   setOperationAction(ISD::CTPOP, MVT::i16, Expand);
 
+  // Atomic ops are lowered to libcalls
   setOperationAction(ISD::ATOMIC_SWAP, MVT::i16, Expand);
   setOperationAction(ISD::ATOMIC_CMP_SWAP, MVT::i16, Expand);
   setOperationAction(ISD::ATOMIC_LOAD_ADD, MVT::i16, Expand);

--- a/llvm/lib/Target/CDM/CDMInstrInfo.td
+++ b/llvm/lib/Target/CDM/CDMInstrInfo.td
@@ -289,6 +289,13 @@ def cdmizeCondXform : SDNodeXForm<cond, [{
 }]>;
 
 //===----------------------------------------------------------------------===//
+// CDM target feature predicates
+//===----------------------------------------------------------------------===//
+
+def HasExtM : Predicate<"Subtarget->hasExtM()">,
+              AssemblerPredicate<(all_of ExtensionM)>;
+
+//===----------------------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 // CDM Instruction list
 //===----------------------------------------------------------------------===//
@@ -460,6 +467,30 @@ def STPC : Inst1Op<0b1001, (outs), (ins CPURegs:$rd), "stpc\t$rd", [(brind CPURe
 def MOVE : Inst2Op<0b0000, (outs CPURegs:$rd), (ins CPURegs:$rs), "move\t$rs, $rd", []> {
   let Defs = [PSR]; // LLVM assumes that copyPhysReg (where MOVE is used) doesn't clobber anything.
                     // This "Defs" isn't considered.
+}
+
+let Constraints = "$rdlo = $rs,$rdhi = $rd", isCommutable = 1, Defs = [PSR] in {
+  // Unsigned multiple
+  // Multiplies rs and rd. Puts the lower half of the result into rs and the upper half into rd.
+  def UMUL : Inst2Op<0b1100, (outs CPURegs:$rdlo, CPURegs:$rdhi), (ins CPURegs:$rs, CPURegs:$rd), "umul\t$rs, $rd",
+               [(set CPURegs:$rdlo, CPURegs:$rdhi, (umullohi CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+
+  // Signed multiply
+  // Multiplies rs and rd. Puts the lower half of the result into rs and the upper half into rd.
+  def SMUL : Inst2Op<0b1101, (outs CPURegs:$rdlo, CPURegs:$rdhi), (ins CPURegs:$rs, CPURegs:$rd), "smul\t$rs, $rd",
+               [(set CPURegs:$rdlo, CPURegs:$rdhi, (smullohi CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+}
+
+let Constraints = "$rdquot = $rs,$rdrem = $rd", Defs = [PSR] in {
+  // Unsigned divide
+  // Divides rs by rd. Puts the quotient into rs and the remainder into rd.
+  def UDIV : Inst2Op<0b1110, (outs CPURegs:$rdquot, CPURegs:$rdrem), (ins CPURegs:$rs, CPURegs:$rd), "udiv\t$rs, $rd",
+               [(set CPURegs:$rdquot, CPURegs:$rdrem, (udivrem CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+
+  // Signed divide
+  // Divides rs by rd. Puts the quotient into rs and the remainder into rd.
+  def SDIV : Inst2Op<0b1111, (outs CPURegs:$rdquot, CPURegs:$rdrem), (ins CPURegs:$rs, CPURegs:$rd), "sdiv\t$rs, $rd",
+               [(set CPURegs:$rdquot, CPURegs:$rdrem, (sdivrem CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/CDM/CDMInstrInfo.td
+++ b/llvm/lib/Target/CDM/CDMInstrInfo.td
@@ -292,8 +292,13 @@ def cdmizeCondXform : SDNodeXForm<cond, [{
 // CDM target feature predicates
 //===----------------------------------------------------------------------===//
 
+// mul/div extension
 def HasExtM : Predicate<"Subtarget->hasExtM()">,
               AssemblerPredicate<(all_of ExtensionM)>;
+
+// OS extension
+def HasExtE : Predicate<"Subtarget->hasExtE()">,
+              AssemblerPredicate<(all_of ExtensionE)>;
 
 //===----------------------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
@@ -458,6 +463,14 @@ def STPC : Inst1Op<0b1001, (outs), (ins CPURegs:$rd), "stpc\t$rd", [(brind CPURe
   let isIndirectBranch = 1;
 }
 
+// Load shadow SP
+// Copies value from shadow SP to rd.
+def LDSSP : Inst1Op<0b1110, (outs CPURegs:$rd), (ins), "ldssp\t$rd", []>, Requires<[HasExtE]>;
+
+// Store shadow SP
+// Copies value from rd to shadow SP.
+def STSSP : Inst1Op<0b1111, (outs), (ins CPURegs:$rd), "stssp\t$rd", []>, Requires<[HasExtE]>;
+
 //===----------------------------------------------------------------------===//
 // 2op format
 //===----------------------------------------------------------------------===//
@@ -473,25 +486,42 @@ let Constraints = "$rdlo = $rs,$rdhi = $rd", isCommutable = 1, Defs = [PSR] in {
   // Unsigned multiple
   // Multiplies rs and rd. Puts the lower half of the result into rs and the upper half into rd.
   def UMUL : Inst2Op<0b1100, (outs CPURegs:$rdlo, CPURegs:$rdhi), (ins CPURegs:$rs, CPURegs:$rd), "umul\t$rs, $rd",
-               [(set CPURegs:$rdlo, CPURegs:$rdhi, (umullohi CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+               [(set CPURegs:$rdlo, CPURegs:$rdhi, (umullohi CPURegs:$rs, CPURegs:$rd))]>,
+             Requires<[HasExtM]>;
 
   // Signed multiply
   // Multiplies rs and rd. Puts the lower half of the result into rs and the upper half into rd.
   def SMUL : Inst2Op<0b1101, (outs CPURegs:$rdlo, CPURegs:$rdhi), (ins CPURegs:$rs, CPURegs:$rd), "smul\t$rs, $rd",
-               [(set CPURegs:$rdlo, CPURegs:$rdhi, (smullohi CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+               [(set CPURegs:$rdlo, CPURegs:$rdhi, (smullohi CPURegs:$rs, CPURegs:$rd))]>,
+             Requires<[HasExtM]>;
 }
 
 let Constraints = "$rdquot = $rs,$rdrem = $rd", Defs = [PSR] in {
   // Unsigned divide
   // Divides rs by rd. Puts the quotient into rs and the remainder into rd.
   def UDIV : Inst2Op<0b1110, (outs CPURegs:$rdquot, CPURegs:$rdrem), (ins CPURegs:$rs, CPURegs:$rd), "udiv\t$rs, $rd",
-               [(set CPURegs:$rdquot, CPURegs:$rdrem, (udivrem CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+               [(set CPURegs:$rdquot, CPURegs:$rdrem, (udivrem CPURegs:$rs, CPURegs:$rd))]>,
+             Requires<[HasExtM]>;
 
   // Signed divide
   // Divides rs by rd. Puts the quotient into rs and the remainder into rd.
   def SDIV : Inst2Op<0b1111, (outs CPURegs:$rdquot, CPURegs:$rdrem), (ins CPURegs:$rs, CPURegs:$rd), "sdiv\t$rs, $rd",
-               [(set CPURegs:$rdquot, CPURegs:$rdrem, (sdivrem CPURegs:$rs, CPURegs:$rd))]>, Requires<[HasExtM]>;
+               [(set CPURegs:$rdquot, CPURegs:$rdrem, (sdivrem CPURegs:$rs, CPURegs:$rd))]>,
+             Requires<[HasExtM]>;
 }
+
+let Constraints = "$rdold = $rd" in {
+  // Atomic swap words
+  def SWPW : Inst2Op<0b0010, (outs CPURegs:$rdold), (ins CPURegs:$rs, CPURegs:$rd), "swpw\t$rs, $rd", []>,
+             Requires<[HasExtE]>;
+
+  // Atomic swap bytes (zero extend)
+  def SWPB : Inst2Op<0b0011, (outs CPURegs:$rdold), (ins CPURegs:$rs, CPURegs:$rd), "swpb\t$rs, $rd", []>,
+             Requires<[HasExtE]>;
+}
+
+// CDM8-like alias
+def SWP : MnemonicAlias<"swp", "swpw">;
 
 //===----------------------------------------------------------------------===//
 // mem2/mem3 format
@@ -648,6 +678,9 @@ def TST : InstAlias<"tst\t$rd", (CMPImm6 CPURegs:$rd, 0)>;
 // Software interrupt
 // Triggers an interrupt with vector with number imm9.
 def INT : InstImm9<0b0000, (outs), (ins interruptVec:$imm), "int\t$imm", []>;
+
+// System call is "int 0x7"
+def SYSCALL : InstAlias<"syscall", (INT 7)>, Requires<[HasExtE]>;
 
 // Reset processor
 // Fetches reset vector thus performing soft reset.

--- a/llvm/lib/Target/CDM/CDMIselDAGToDAG.h
+++ b/llvm/lib/Target/CDM/CDMIselDAGToDAG.h
@@ -19,6 +19,7 @@ public:
 
 private:
 #include "CDMGenDAGISel.inc"
+  const CDMSubtarget *Subtarget = nullptr;
 
   void Select(SDNode *N) override;
   bool trySelectPointerCall(SDNode *N);
@@ -27,11 +28,17 @@ private:
   bool selectAddr(SDNode *Op, SDValue N, SDValue &Addr);
   bool selectAddr2Reg(SDNode *Op, SDValue N, SDValue &Base, SDValue &Offset);
   bool selectConstAddr(SDNode *Op, SDValue N, SDValue &Addr);
-  bool selectConstAddr2Reg(SDNode *Op, SDValue N, SDValue &Base, SDValue &Offset);
+  bool selectConstAddr2Reg(SDNode *Op, SDValue N, SDValue &Base,
+                           SDValue &Offset);
 
   bool SelectInlineAsmMemoryOperand(const SDValue &Op,
                                     InlineAsm::ConstraintCode ConstraintID,
                                     std::vector<SDValue> &OutOps) override;
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    Subtarget = &MF.getSubtarget<CDMSubtarget>();
+    return SelectionDAGISel::runOnMachineFunction(MF);
+  }
 
   inline CDMCOND::CondOp condCodeToCDMCond(ISD::CondCode CC) const {
     switch (CC) {

--- a/llvm/lib/Target/CDM/CDMSubtarget.cpp
+++ b/llvm/lib/Target/CDM/CDMSubtarget.cpp
@@ -3,12 +3,10 @@
 //
 
 #include "CDMSubtarget.h"
-
-// ..MachineFunction
-// ...RegisterInfo
 #include "CDMTargetMachine.h"
 
 using namespace llvm;
+
 #define DEBUG_TYPE "cdm-subtarget"
 
 #define GET_SUBTARGETINFO_TARGET_DESC
@@ -18,10 +16,8 @@ using namespace llvm;
 CDMSubtarget::CDMSubtarget(const Triple &TT, StringRef CPU, StringRef FS,
                            const CDMTargetMachine &TM)
     : CDMGenSubtargetInfo(TT, CPU, CPU, FS),
-      InstrInfo(std::make_unique<CDMInstrInfo>()),
-      FrameLowering(std::make_unique<CDMFrameLowering>(
-          initializeSubtargetDependencies(CPU, FS, TM))),
-      TLInfo(std::make_unique<CDMISelLowering>(TM, *this))
+      FrameLowering(initializeSubtargetDependencies(CPU, FS, TM)), InstrInfo(),
+      TLInfo(TM, *this)
 
 {
   ParseSubtargetFeatures(CPU, /*TuneCPU*/ CPU, FS);
@@ -32,8 +28,4 @@ CDMSubtarget::initializeSubtargetDependencies(StringRef CPU, StringRef FS,
                                               const TargetMachine &TM) {
   ParseSubtargetFeatures(CPU, /*TuneCPU*/ CPU, FS);
   return *this;
-}
-
-const TargetFrameLowering *CDMSubtarget::getFrameLowering() const {
-  return FrameLowering.get();
 }

--- a/llvm/lib/Target/CDM/CDMSubtarget.cpp
+++ b/llvm/lib/Target/CDM/CDMSubtarget.cpp
@@ -19,10 +19,21 @@ CDMSubtarget::CDMSubtarget(const Triple &TT, StringRef CPU, StringRef FS,
                            const CDMTargetMachine &TM)
     : CDMGenSubtargetInfo(TT, CPU, CPU, FS),
       InstrInfo(std::make_unique<CDMInstrInfo>()),
-      FrameLowering(std::make_unique<CDMFrameLowering>(*this)),
+      FrameLowering(std::make_unique<CDMFrameLowering>(
+          initializeSubtargetDependencies(CPU, FS, TM))),
       TLInfo(std::make_unique<CDMISelLowering>(TM, *this))
 
-{}
+{
+  ParseSubtargetFeatures(CPU, /*TuneCPU*/ CPU, FS);
+}
+
+CDMSubtarget &
+CDMSubtarget::initializeSubtargetDependencies(StringRef CPU, StringRef FS,
+                                              const TargetMachine &TM) {
+  ParseSubtargetFeatures(CPU, /*TuneCPU*/ CPU, FS);
+  return *this;
+}
+
 const TargetFrameLowering *CDMSubtarget::getFrameLowering() const {
   return FrameLowering.get();
 }

--- a/llvm/lib/Target/CDM/CDMSubtarget.h
+++ b/llvm/lib/Target/CDM/CDMSubtarget.h
@@ -26,6 +26,7 @@ public:
   CDMSubtarget(const Triple &TT, StringRef CPU, StringRef FS,
                const CDMTargetMachine &TM);
   void ParseSubtargetFeatures(StringRef CPU, StringRef TuneCPU, StringRef FS);
+
   const CDMISelLowering *getTargetLowering() const override {
     return TLInfo.get();
   }
@@ -38,10 +39,22 @@ public:
     return &TSInfo;
   }
 
+  CDMSubtarget &initializeSubtargetDependencies(StringRef CPU, StringRef FS,
+                                                const TargetMachine &TM);
+
+#define GET_SUBTARGETINFO_MACRO(ATTRIBUTE, DEFAULT, GETTER)                    \
+  bool GETTER() const { return ATTRIBUTE; }
+#include "CDMGenSubtargetInfo.inc"
+
 protected:
   std::unique_ptr<const CDMInstrInfo> InstrInfo;
   std::unique_ptr<const CDMFrameLowering> FrameLowering;
   std::unique_ptr<const CDMISelLowering> TLInfo;
+
+private:
+#define GET_SUBTARGETINFO_MACRO(ATTRIBUTE, DEFAULT, GETTER)                    \
+  bool ATTRIBUTE = DEFAULT;
+#include "CDMGenSubtargetInfo.inc"
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/CDM/CDMSubtarget.h
+++ b/llvm/lib/Target/CDM/CDMSubtarget.h
@@ -25,36 +25,36 @@ class CDMSubtarget : public CDMGenSubtargetInfo {
 public:
   CDMSubtarget(const Triple &TT, StringRef CPU, StringRef FS,
                const CDMTargetMachine &TM);
+
   void ParseSubtargetFeatures(StringRef CPU, StringRef TuneCPU, StringRef FS);
 
-  const CDMISelLowering *getTargetLowering() const override {
-    return TLInfo.get();
+  const CDMISelLowering *getTargetLowering() const override { return &TLInfo; }
+  const TargetFrameLowering *getFrameLowering() const override {
+    return &FrameLowering;
   }
-  const TargetFrameLowering *getFrameLowering() const override;
-  const CDMInstrInfo *getInstrInfo() const override { return InstrInfo.get(); }
+  const CDMInstrInfo *getInstrInfo() const override { return &InstrInfo; }
   const CDMRegisterInfo *getRegisterInfo() const override {
-    return &(InstrInfo->getRegisterInfo());
+    return &InstrInfo.getRegisterInfo();
   }
   const SelectionDAGTargetInfo *getSelectionDAGInfo() const override {
     return &TSInfo;
   }
 
-  CDMSubtarget &initializeSubtargetDependencies(StringRef CPU, StringRef FS,
-                                                const TargetMachine &TM);
-
 #define GET_SUBTARGETINFO_MACRO(ATTRIBUTE, DEFAULT, GETTER)                    \
   bool GETTER() const { return ATTRIBUTE; }
 #include "CDMGenSubtargetInfo.inc"
 
-protected:
-  std::unique_ptr<const CDMInstrInfo> InstrInfo;
-  std::unique_ptr<const CDMFrameLowering> FrameLowering;
-  std::unique_ptr<const CDMISelLowering> TLInfo;
-
 private:
+  CDMFrameLowering FrameLowering;
+  CDMInstrInfo InstrInfo;
+  CDMISelLowering TLInfo;
+
 #define GET_SUBTARGETINFO_MACRO(ATTRIBUTE, DEFAULT, GETTER)                    \
   bool ATTRIBUTE = DEFAULT;
 #include "CDMGenSubtargetInfo.inc"
+
+  CDMSubtarget &initializeSubtargetDependencies(StringRef CPU, StringRef FS,
+                                                const TargetMachine &TM);
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/CDM/CDMTargetMachine.cpp
+++ b/llvm/lib/Target/CDM/CDMTargetMachine.cpp
@@ -32,7 +32,7 @@ CDMTargetMachine::CDMTargetMachine(const Target &T, const Triple &TT,
     : CodeGenTargetMachineImpl(T, computeDataLayout(), TT, CPU, FS, Options,
                                Reloc::Static, CodeModel::Small, OL),
       TLOF(std::make_unique<CDMTargetObjectFile>()),
-      DataLayout(computeDataLayout()), DefaultSubtarget(TT, CPU, FS, *this) {
+      DataLayout(computeDataLayout()), Subtarget(TT, CPU, FS, *this) {
   initAsmInfo();
   //  Options.EmitAddrsig = false;
 }

--- a/llvm/lib/Target/CDM/CDMTargetMachine.h
+++ b/llvm/lib/Target/CDM/CDMTargetMachine.h
@@ -11,7 +11,7 @@ namespace llvm {
 class CDMTargetMachine : public CodeGenTargetMachineImpl {
   std::unique_ptr<TargetLoweringObjectFile> TLOF;
   const DataLayout DataLayout;
-  CDMSubtarget DefaultSubtarget;
+  CDMSubtarget Subtarget;
 
 public:
   CDMTargetMachine(const Target &T, const Triple &TT, StringRef CPU,
@@ -27,7 +27,7 @@ public:
     return TLOF.get();
   }
   const CDMSubtarget *getSubtargetImpl(const Function &F) const override {
-    return &DefaultSubtarget;
+    return &Subtarget;
   }
 
   MachineFunctionInfo *

--- a/llvm/lib/TargetParser/CDMTargetParser.cpp
+++ b/llvm/lib/TargetParser/CDMTargetParser.cpp
@@ -1,0 +1,29 @@
+#include "llvm/TargetParser/CDMTargetParser.h"
+
+using namespace llvm;
+using namespace llvm::CDM;
+
+const ExtensionInfo AllExtensions[] = {
+#define CDM_EXTENSION(ARCH_NAME, FLAG_NAME) {ARCH_NAME, FLAG_NAME},
+#include "llvm/TargetParser/CDMTargetParser.def"
+};
+
+bool CDM::getArchFeatures(StringRef Arch, std::vector<StringRef> &Features) {
+  if (!Arch.starts_with("cdm16")) {
+    return false;
+  }
+  for (const char &Ch : Arch.slice(5, -1)) {
+    bool Valid = false;
+    for (const auto &Ext : AllExtensions) {
+      if (Ext.ArchName == Ch) {
+        Features.push_back(Ext.FlagName);
+        Valid = true;
+        break;
+      }
+    }
+    if (!Valid) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/llvm/lib/TargetParser/CMakeLists.txt
+++ b/llvm/lib/TargetParser/CMakeLists.txt
@@ -18,6 +18,7 @@ add_llvm_component_library(LLVMTargetParser
   ARMTargetParserCommon.cpp
   ARMTargetParser.cpp
   CSKYTargetParser.cpp
+  CDMTargetParser.cpp
   Host.cpp
   LoongArchTargetParser.cpp
   PPCTargetParser.cpp

--- a/llvm/test/CodeGen/CDM/ext_muldiv.ll
+++ b/llvm/test/CodeGen/CDM/ext_muldiv.ll
@@ -1,0 +1,40 @@
+target datalayout = "e-m:e-p:16:16-i8:8-i16:16-i32:16-i64:16-f16:16-f32:16-f64:16-f128:16-n16-S16"
+
+; RUN: llc -mtriple=cdm-cocas -mattr=+m < %s | FileCheck %s
+
+; Lowering of trap intrinsics
+
+define i16 @mul(i16 %a, i16 %b) {
+; CHECK-LABEL: mul>
+; CHECK: smul {{r[0-6]}}, {{r[0-6]}}
+    %result = mul i16 %a, %b
+    ret i16 %result
+}
+
+define i16 @sdiv(i16 %a, i16 %b) {
+; CHECK-LABEL: sdiv>
+; CHECK: sdiv {{r[0-6]}}, {{r[0-6]}}
+    %result = sdiv i16 %a, %b
+    ret i16 %result
+}
+
+define i16 @udiv(i16 %a, i16 %b) {
+; CHECK-LABEL: udiv>
+; CHECK: udiv {{r[0-6]}}, {{r[0-6]}}
+    %result = udiv i16 %a, %b
+    ret i16 %result
+}
+
+define i16 @srem(i16 %a, i16 %b) {
+; CHECK-LABEL: srem>
+; CHECK: sdiv {{r[0-6]}}, {{r[0-6]}}
+    %result = srem i16 %a, %b
+    ret i16 %result
+}
+
+define i16 @urem(i16 %a, i16 %b) {
+; CHECK-LABEL: urem>
+; CHECK: udiv {{r[0-6]}}, {{r[0-6]}}
+    %result = urem i16 %a, %b
+    ret i16 %result
+}


### PR DESCRIPTION
This PR adds support for [`cdm16e`](https://github.com/cdm-processors/cdm-devkit/blob/3e8f705736b2d2ea601a747b60db169908bdaa4a/docs/cdm16e/cdm16e-overview.md) and [`cdm16m`](https://github.com/cdm-processors/cdm-devkit/pull/105) extensions.

closes: #108 