### PR TITLE
`crt0` fixes

### DIFF
--- a/cdm-rt/cdm-cocas/crt0/crt0.asm
+++ b/cdm-rt/cdm-cocas/crt0/crt0.asm
@@ -27,7 +27,11 @@ _cdm_default_handlers_end:
   halt
 
 _start>
+  ldi fp, 0
+  stsp fp
+  addsp -8
   jsr main
+  addsp 8
   halt
 
 end.

--- a/cdm-rt/cdm-elf/crt0/crt0-harvard.s
+++ b/cdm-rt/cdm-elf/crt0/crt0-harvard.s
@@ -1,7 +1,5 @@
-.section .ivt.reset_vector, "a", @progbits
-.short _start, 0
-
 .section .ivt.exceptions, "a", @progbits
+.short _start, 0
 .short _ex_unaligned_sp, 0x1
 .short _ex_unaligned_pc, 0x2
 .short _ex_invalid_inst, 0x3

--- a/cdm-rt/cdm-elf/crt0/crt0-harvard.s
+++ b/cdm-rt/cdm-elf/crt0/crt0-harvard.s
@@ -55,7 +55,9 @@ add r1, -2
 bnz 0b
 
 # Hand control over to user code
+addsp -8
 jsr main
+addsp 8
 halt
 
 .global _default_handler

--- a/cdm-rt/cdm-elf/crt0/crt0-harvard.s
+++ b/cdm-rt/cdm-elf/crt0/crt0-harvard.s
@@ -2,10 +2,21 @@
 .short _start, 0
 
 .section .ivt.exceptions, "a", @progbits
-.short _unaligned_sp, 1
-.short _unaligned_pc, 2
-.short _invalid_inst, 3
-.short _double_fault, 4
+.short _ex_unaligned_sp, 0x1
+.short _ex_unaligned_pc, 0x2
+.short _ex_invalid_inst, 0x3
+.short _ex_double_fault, 0x4
+.short _ex_priv_violation, 0x5
+.short _ex_reserved_6, 0x6
+.short _ex_syscall, 0x7
+.short _ex_reserved_8, 0x8
+.short _ex_reserved_9, 0x9
+.short _ex_reserved_a, 0xa
+.short _ex_reserved_b, 0xb
+.short _ex_reserved_c, 0xc
+.short _ex_reserved_d, 0xd
+.short _ex_reserved_e, 0xe
+.short _ex_reserved_f, 0xf
 
 .section .text._start, "ax", @progbits
 .global _start

--- a/cdm-rt/cdm-elf/crt0/crt0-vonNeumann.s
+++ b/cdm-rt/cdm-elf/crt0/crt0-vonNeumann.s
@@ -24,7 +24,9 @@
 _start:
 ldi fp, __stack_start
 stsp fp
+addsp -8
 jsr main
+addsp 8
 halt
 
 .global _default_handler

--- a/cdm-rt/cdm-elf/crt0/crt0-vonNeumann.s
+++ b/cdm-rt/cdm-elf/crt0/crt0-vonNeumann.s
@@ -1,7 +1,5 @@
-.section .ivt.reset_vector, "a", @progbits
-.short _start, 0
-
 .section .ivt.exceptions, "a", @progbits
+.short _start, 0x0
 .short _ex_unaligned_sp, 0x1
 .short _ex_unaligned_pc, 0x2
 .short _ex_invalid_inst, 0x3

--- a/cdm-rt/cdm-elf/crt0/crt0-vonNeumann.s
+++ b/cdm-rt/cdm-elf/crt0/crt0-vonNeumann.s
@@ -2,10 +2,21 @@
 .short _start, 0
 
 .section .ivt.exceptions, "a", @progbits
-.short _unaligned_sp, 1
-.short _unaligned_pc, 2
-.short _invalid_inst, 3
-.short _double_fault, 4
+.short _ex_unaligned_sp, 0x1
+.short _ex_unaligned_pc, 0x2
+.short _ex_invalid_inst, 0x3
+.short _ex_double_fault, 0x4
+.short _ex_priv_violation, 0x5
+.short _ex_reserved_6, 0x6
+.short _ex_syscall, 0x7
+.short _ex_reserved_8, 0x8
+.short _ex_reserved_9, 0x9
+.short _ex_reserved_a, 0xa
+.short _ex_reserved_b, 0xb
+.short _ex_reserved_c, 0xc
+.short _ex_reserved_d, 0xd
+.short _ex_reserved_e, 0xe
+.short _ex_reserved_f, 0xf
 
 .section .text._start, "ax", @progbits
 .global _start

--- a/cdm-rt/cdm-elf/ldscripts/cdm-harvard.ld
+++ b/cdm-rt/cdm-elf/ldscripts/cdm-harvard.ld
@@ -3,10 +3,21 @@ EXTERN(_default_handler);
 PROVIDE(_exception_handler = _default_handler);
 PROVIDE(_interrupt_handler = _default_handler);
 
-PROVIDE(_unaligned_sp = _exception_handler);
-PROVIDE(_unaligned_pc = _exception_handler);
-PROVIDE(_invalid_inst = _exception_handler);
-PROVIDE(_double_fault = _exception_handler);
+PROVIDE(_ex_unaligned_sp = _exception_handler);
+PROVIDE(_ex_unaligned_pc = _exception_handler);
+PROVIDE(_ex_invalid_inst = _exception_handler);
+PROVIDE(_ex_double_fault = _exception_handler);
+PROVIDE(_ex_priv_violation = _exception_handler);
+PROVIDE(_ex_reserved_6 = _exception_handler);
+PROVIDE(_ex_syscall = _exception_handler);
+PROVIDE(_ex_reserved_8 = _exception_handler);
+PROVIDE(_ex_reserved_9 = _exception_handler);
+PROVIDE(_ex_reserved_a = _exception_handler);
+PROVIDE(_ex_reserved_b = _exception_handler);
+PROVIDE(_ex_reserved_c = _exception_handler);
+PROVIDE(_ex_reserved_d = _exception_handler);
+PROVIDE(_ex_reserved_e = _exception_handler);
+PROVIDE(_ex_reserved_f = _exception_handler);
 
 MEMORY {
     PROGMEM : ORIGIN = 0x0, LENGTH = 64K
@@ -64,4 +75,4 @@ ASSERT(RAM_ORIGIN % 2 != 0 || RAM_LENGTH % 2 == 0, "ERROR(cdm-rt): RAM_LENGTH mu
 ASSERT(__vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): missing reset vector");
 ASSERT(__vector_table_ex == __vector_table || __vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): invalid reset vector");
 ASSERT(__vector_table_int != __vector_table_ex, "ERROR(cdm-rt): missing exception vectors");
-ASSERT(__vector_table_int == __vector_table_ex || __vector_table_int == __vector_table_ex + 0x10, "ERROR(cdm-rt): incorrect number of exception vectors");
+ASSERT(__vector_table_int == __vector_table_ex || __vector_table_int == __vector_table_ex + 15 * 0x4, "ERROR(cdm-rt): incorrect number of exception vectors");

--- a/cdm-rt/cdm-elf/ldscripts/cdm-harvard.ld
+++ b/cdm-rt/cdm-elf/ldscripts/cdm-harvard.ld
@@ -31,8 +31,6 @@ SECTIONS
 {
   .ivt 0x00 : {             /* Interrupt vector table */
     __vector_table = .;
-    KEEP(*(.ivt.reset_vector));
-    __vector_table_ex = .;
     KEEP(*(.ivt.exceptions));
     __vector_table_int = .;
     KEEP(*(.ivt.interrupts));
@@ -72,7 +70,5 @@ SECTIONS
 
 ASSERT(RAM_ORIGIN % 2 == 0, "ERROR(cdm-rt): RAM_ORIGIN must be a multiple of 2");
 ASSERT(RAM_ORIGIN % 2 != 0 || RAM_LENGTH % 2 == 0, "ERROR(cdm-rt): RAM_LENGTH must be a multiple of 2");
-ASSERT(__vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): missing reset vector");
-ASSERT(__vector_table_ex == __vector_table || __vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): invalid reset vector");
-ASSERT(__vector_table_int != __vector_table_ex, "ERROR(cdm-rt): missing exception vectors");
-ASSERT(__vector_table_int == __vector_table_ex || __vector_table_int == __vector_table_ex + 15 * 0x4, "ERROR(cdm-rt): incorrect number of exception vectors");
+ASSERT(__vector_table_int != __vector_table, "ERROR(cdm-rt): missing exception vectors");
+ASSERT(__vector_table_int == __vector_table || __vector_table_int == __vector_table + 16 * 0x4, "ERROR(cdm-rt): incorrect number of exception vectors (must be 16)");

--- a/cdm-rt/cdm-elf/ldscripts/cdm-vonNeumann.ld
+++ b/cdm-rt/cdm-elf/ldscripts/cdm-vonNeumann.ld
@@ -31,8 +31,6 @@ SECTIONS
 {
   .ivt 0x00 : {             /* Interrupt vector table */
     __vector_table = .;
-    KEEP(*(.ivt.reset_vector));
-    __vector_table_ex = .;
     KEEP(*(.ivt.exceptions));
     __vector_table_int = .;
     KEEP(*(.ivt.interrupts));
@@ -65,7 +63,5 @@ SECTIONS
 
 ASSERT(RAM_ORIGIN % 2 == 0, "ERROR(cdm-rt): RAM_ORIGIN must be a multiple of 2");
 ASSERT(RAM_ORIGIN % 2 != 0 || RAM_LENGTH % 2 == 0, "ERROR(cdm-rt): RAM_LENGTH must be a multiple of 2");
-ASSERT(__vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): missing reset vector");
-ASSERT(__vector_table_ex == __vector_table || __vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): invalid reset vector");
-ASSERT(__vector_table_int != __vector_table_ex, "ERROR(cdm-rt): missing exception vectors");
-ASSERT(__vector_table_int == __vector_table_ex || __vector_table_int == __vector_table_ex + 15 * 0x4, "ERROR(cdm-rt): incorrect number of exception vectors");
+ASSERT(__vector_table_int != __vector_table, "ERROR(cdm-rt): missing exception vectors");
+ASSERT(__vector_table_int == __vector_table || __vector_table_int == __vector_table + 16 * 0x4, "ERROR(cdm-rt): incorrect number of exception vectors (must be 16)");

--- a/cdm-rt/cdm-elf/ldscripts/cdm-vonNeumann.ld
+++ b/cdm-rt/cdm-elf/ldscripts/cdm-vonNeumann.ld
@@ -3,10 +3,21 @@ EXTERN(_default_handler);
 PROVIDE(_exception_handler = _default_handler);
 PROVIDE(_interrupt_handler = _default_handler);
 
-PROVIDE(_unaligned_sp = _exception_handler);
-PROVIDE(_unaligned_pc = _exception_handler);
-PROVIDE(_invalid_inst = _exception_handler);
-PROVIDE(_double_fault = _exception_handler);
+PROVIDE(_ex_unaligned_sp = _exception_handler);
+PROVIDE(_ex_unaligned_pc = _exception_handler);
+PROVIDE(_ex_invalid_inst = _exception_handler);
+PROVIDE(_ex_double_fault = _exception_handler);
+PROVIDE(_ex_priv_violation = _exception_handler);
+PROVIDE(_ex_reserved_6 = _exception_handler);
+PROVIDE(_ex_syscall = _exception_handler);
+PROVIDE(_ex_reserved_8 = _exception_handler);
+PROVIDE(_ex_reserved_9 = _exception_handler);
+PROVIDE(_ex_reserved_a = _exception_handler);
+PROVIDE(_ex_reserved_b = _exception_handler);
+PROVIDE(_ex_reserved_c = _exception_handler);
+PROVIDE(_ex_reserved_d = _exception_handler);
+PROVIDE(_ex_reserved_e = _exception_handler);
+PROVIDE(_ex_reserved_f = _exception_handler);
 
 MEMORY {
     IVT : ORIGIN = 0x0, LENGTH = 0x100
@@ -57,4 +68,4 @@ ASSERT(RAM_ORIGIN % 2 != 0 || RAM_LENGTH % 2 == 0, "ERROR(cdm-rt): RAM_LENGTH mu
 ASSERT(__vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): missing reset vector");
 ASSERT(__vector_table_ex == __vector_table || __vector_table_ex == __vector_table + 0x4, "ERROR(cdm-rt): invalid reset vector");
 ASSERT(__vector_table_int != __vector_table_ex, "ERROR(cdm-rt): missing exception vectors");
-ASSERT(__vector_table_int == __vector_table_ex || __vector_table_int == __vector_table_ex + 0x10, "ERROR(cdm-rt): incorrect number of exception vectors");
+ASSERT(__vector_table_int == __vector_table_ex || __vector_table_int == __vector_table_ex + 15 * 0x4, "ERROR(cdm-rt): incorrect number of exception vectors");

--- a/cdm-rt/common/include/cdm/ivt.h
+++ b/cdm-rt/common/include/cdm/ivt.h
@@ -20,10 +20,8 @@ ISR void _interrupt_handler(void);
 // The default interrupt vector for unused interrupts.
 #define DEFAULT_VECTOR ((ivt_vector_t){ _interrupt_handler, 0 })
 
-// The number of standard exception handler entries in the IVT.
-#define EXCEPTION_COUNT 15
-// The starting index of the user interrupt handler section of the IVT.
-#define INTERRUPT_START 16
+// The number of standard exception handler entries (including the reset vector) in the IVT.
+#define EXCEPTION_COUNT 16
 // The number of user interrupt handler entries in the IVT.
 #define INTERRUPT_COUNT 48
 

--- a/cdm-rt/common/include/cdm/ivt.h
+++ b/cdm-rt/common/include/cdm/ivt.h
@@ -21,11 +21,11 @@ ISR void _interrupt_handler(void);
 #define DEFAULT_VECTOR ((ivt_vector_t){ _interrupt_handler, 0 })
 
 // The number of standard exception handler entries in the IVT.
-#define EXCEPTION_COUNT 4
+#define EXCEPTION_COUNT 15
 // The starting index of the user interrupt handler section of the IVT.
-#define INTERRUPT_START 5
+#define INTERRUPT_START 16
 // The number of user interrupt handler entries in the IVT.
-#define INTERRUPT_COUNT 59
+#define INTERRUPT_COUNT 48
 
 #ifndef __COCAS__
 #define __CDM_RT_IVT_COUNT(...) __CDM_RT_IVT_COUNT_(__VA_ARGS__ __VA_OPT__(,)  \


### PR DESCRIPTION
The [README for the CDM org](https://github.com/cdm-processors) states that the first 16 vectors are exceptions. CDM-16e also introduces two new exceptions. I think it is a good idea to reserve the first 16 vectors for CDM-16e and future extensions.